### PR TITLE
Added ingress resource template

### DIFF
--- a/deployment/templates/ingress.yaml
+++ b/deployment/templates/ingress.yaml
@@ -1,0 +1,49 @@
+{{- if  .Values.ingress.enabled }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    {{- if .Values.ingress.https.enabled }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.https.issuer }}
+    kubernetes.io/tls-acme: {{ quote .Values.ingress.https.enabled}}
+    {{- end }}
+  name: pubgrade-ingress
+spec:
+  rules:
+  - host: {{ .Values.ingress.url }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: pubgrade-service
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+  {{- if .Values.ingress.https.enabled }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.url }}
+    secretName: pubgrade-ingress-secret
+  {{- end }}
+{{- else if .Capabilities.APIVersions.Has "route.openshift.io/v1/Route" -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: pubgrade-ingress
+spec:
+  host: {{ .Values.ingress.url }}
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: pubgrade-service
+    weight: 100
+  wildcardPolicy: None
+status:
+  ingress: []
+{{- end }}
+{{- end }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -1,6 +1,13 @@
 imageNotifyCompletion: 'akash7778/notify-completion' # This will be moved to elixir-cloud-aai
 pubgrade_URL: 'http://pubgrade-service.pubgrade'
 
+ingress:
+  enabled: true
+  url: 'your.url.without.http.com'
+  https:
+    enabled: true
+    issuer: letsencrypt-prod
+
 #Persistent volumes and claims
 volumes:
   Pubgrade:


### PR DESCRIPTION
## Description

This PR adds a template for an ingress resource (K8s/OpenShift) so that Pubgrade is accessible via an http/https link. A test deployment can be found here: https://pubgrade.hypatia-comp.athenarc.gr/


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not reduced the existing code coverage
- [ ] I have updated any sections of the app's documentation that are affected by the proposed changes, if applicable
