### PR TITLE
feat | GitHub workflow to pull and sign images

### DIFF
--- a/.github/workflows/image-signer.yaml
+++ b/.github/workflows/image-signer.yaml
@@ -1,0 +1,69 @@
+name: Pull and Sign Container Image
+
+on:
+  repository_dispatch:
+    types: [sign-image]  
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # Required for OIDC token access
+
+jobs:
+  build-and-sign:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Log in to Docker Hub
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ github.event.client_payload.docker_username }}
+          password: ${{ github.event.client_payload.docker_password }}
+
+      # Pull the container image
+      - name: Pull Image
+        run: docker pull ${{ github.event.client_payload.pull_tag }}
+
+      - name: Extract image name
+        run: |
+          IMAGE_TAG=${{ github.event.client_payload.push_tag }}
+          IMAGE_NAME=$(echo $IMAGE_TAG | sed 's/:.*//')
+          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
+
+      - name: Get Image Digest
+        id: get-digest
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ github.event.client_payload.pull_tag }} | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
+
+      # Install Cosign
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.2.1' # Use a specific version for stability
+
+      - name: Tag changed
+        run: docker tag ${{ github.event.client_payload.pull_tag }} ${{ github.event.client_payload.push_tag }}
+      
+      - name: Push Tagged Image
+        run: docker push ${{ github.event.client_payload.push_tag }}
+          
+      - name: Sign container image
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: |
+          cosign sign --yes ${{ github.event.client_payload.push_tag }}
+
+     # Output the digest for reference
+      - name: Output Digest for Verification
+        run: |
+          echo "Image pushed and signed as ${{ github.event.client_payload.push_tag }} with digest akash7778/sampletestt@${{ steps.get-digest.outputs.digest }}"
+          echo "Verify with: cosign verify $IMAGE_NAME:${{ steps.get-digest.outputs.digest }}"
+
+

--- a/.github/workflows/image-signer.yaml
+++ b/.github/workflows/image-signer.yaml
@@ -63,7 +63,7 @@ jobs:
      # Output the digest for reference
       - name: Output Digest for Verification
         run: |
-          echo "Image pushed and signed as ${{ github.event.client_payload.push_tag }} with digest akash7778/sampletestt@${{ steps.get-digest.outputs.digest }}"
-          echo "Verify with: cosign verify $IMAGE_NAME:${{ steps.get-digest.outputs.digest }}"
+          echo "Image pushed and signed as ${{ github.event.client_payload.push_tag }} with digest $IMAGE_NAME@${{ steps.get-digest.outputs.digest }}"
+          echo "Verify with: cosign verify $IMAGE_NAME@${{ steps.get-digest.outputs.digest }}"
 
 

--- a/.github/workflows/image-signer.yaml
+++ b/.github/workflows/image-signer.yaml
@@ -60,10 +60,13 @@ jobs:
         run: |
           cosign sign --yes ${{ github.event.client_payload.push_tag }}
 
-     # Output the digest for reference
+      - name: Sign image Verification
+        run: |
+          cosign verify $IMAGE_NAME@${{ steps.get-digest.outputs.digest }}
+
+      # Output the digest for reference
       - name: Output Digest for Verification
         run: |
           echo "Image pushed and signed as ${{ github.event.client_payload.push_tag }} with digest $IMAGE_NAME@${{ steps.get-digest.outputs.digest }}"
           echo "Verify with: cosign verify $IMAGE_NAME@${{ steps.get-digest.outputs.digest }}"
-
 


### PR DESCRIPTION
## Description

This GitHub Actions workflow automates the process of **pulling, tagging, pushing, and signing a container image**. Triggered by a **repository_dispatch** event (sign-image) or manual workflow_dispatch, it runs on an ubuntu-latest environment with the following steps:

1. Checkout Code: Clones the repository using actions/checkout@v4.

1. Docker Hub Login: Authenticates with Docker Hub using provided credentials from repository_dispatch API call.

1. Pull Image: Pulls the specified container image using the pull_tag input.

1. Extract Image Name: Derives the image name from the push_tag input and stores it in the environment.

1. Get Image Digest: Retrieves the image digest for verification.

1. Install Cosign: Installs Cosign (v2.2.1) for signing the image.

1. Tag and Push Image: Tags the pulled image with push_tag and pushes it to Docker Hub.

1. Sign Image: Signs the pushed image using Cosign with experimental features enabled.

1. Output Digest: Logs the signed image's digest for verification.

The workflow uses OIDC token permissions for secure operations and outputs the digest for post-signing verification. It ensures a streamlined process for pulling, tagging, pushing, and cryptographically signing container images.

Fixes #25 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not reduced the existing code coverage
- [ ] I have added docstrings following the [Python style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/python.md) of this project to all new modules, classes, methods and functions are documented with docstrings following; I have updated any previously existing docstrings, if applicable
- [ ] I have updated any sections of the app's documentation that are affected by the proposed changes, if applicable

## Summary by Sourcery

Add a GitHub Actions workflow to automate pulling, tagging, pushing, and signing Docker images with Cosign

New Features:
- Create image-signer workflow triggered by repository_dispatch and manual dispatch
- Automate Docker Hub login, image pull, tag, push, and Cosign-based signing

Enhancements:
- Extract and output the image digest for post-signing verification

CI:
- Grant OIDC id-token permission and configure workflow triggers and jobs